### PR TITLE
enable swift package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/JYImageTool/include/JYImageTool/JYImageTool.h
+++ b/JYImageTool/include/JYImageTool/JYImageTool.h
@@ -1,0 +1,1 @@
+#import "../../JYImageTool.h"

--- a/JYImageTool/include/module.modulemap
+++ b/JYImageTool/include/module.modulemap
@@ -1,0 +1,5 @@
+module JYImageTool {
+    umbrella header "JYImageTool/JYImageTool.h"
+    export *
+    module * { export * }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "JYImageTool",
+    products: [
+        .library(name: "JYImageTool", targets: ["JYImageTool"])
+    ],
+    targets: [
+        .target(
+            name: "JYImageTool",
+            dependencies: [],
+            path: "JYImageTool",
+            exclude: [],
+            sources: ["JYImageCore.h", "JYImageCore.m", "JYImageTool.h", "UIImage+JYImageTool.h", "UIImage+JYImageTool.m"],
+            publicHeadersPath: "include"
+        )
+    ]
+)


### PR DESCRIPTION
add support for swift package manager

notes: 

The version rule requires Swift packages to conform to semantic versioning. To learn more about the semantic versioning standard, visit [semver.org](https://semver.org/). 

source: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency-requirement